### PR TITLE
FIX: V1 fix subsecond durations

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "itty-time",
-  "version": "1.0.5",
+  "version": "1.0.5-next.0",
   "description": "Ultra-small (~390 bytes) library for TTL date math and converting ms durations to and from strings.",
   "main": "./index.js",
   "module": "./index.mjs",

--- a/src/datePlus.spec.ts
+++ b/src/datePlus.spec.ts
@@ -38,4 +38,22 @@ describe('datePlus(duration: string, from?: Date): Date', () => {
       })
     }
   })
+
+  // describe('BAD INPUTS', () => {
+  //   const inputTypes = [
+  //     ['object', {}],
+  //     ['number', 1011],
+  //     ['true', true],
+  //     ['false', false],
+  //     ['date', new Date],
+  //     // ['function', () => {}],
+  //   ]
+
+  //   for (const [type, value] of inputTypes) {
+  //     it(`when receiving ${type} as first argument`, () => {
+  //       // @ts-ignore
+  //       expect(() => datePlus(value)).toThrow()
+  //     })
+  //   }
+  // })
 })

--- a/src/duration.spec.ts
+++ b/src/duration.spec.ts
@@ -45,4 +45,33 @@ describe('duration(ms: number, options?: durationOptions)', () => {
       })
     })
   })
+
+  describe('INPUT HANDLING', () => {
+    const date = new Date
+
+    const inputTypes = [
+      { type: 'number', value: 0, returns: '0 seconds' },
+      { type: 'number', value: 1000, returns: '1 second' },
+      { type: 'number', value: 500, returns: '0.5 seconds' },
+      { type: 'number', value: 10000, returns: '10 seconds' },
+      { type: 'string duration', value: '1 hour', returns: 'NaN seconds' },
+      { type: 'true', value: true, returns: '0.001 seconds' },
+      { type: 'date', value: date },
+      { type: 'false', value: false, returns: '0 seconds' },
+      { type: 'unparsable string', value: '456apple', returns: 'NaN seconds' },
+      { type: 'object', value: {}, returns: 'NaN seconds' },
+      { type: 'function', value: () => {}, returns: 'NaN seconds' },
+    ]
+
+    for (const { type, value, returns } of inputTypes) {
+      const expected = `return ${returns !== undefined ? returns || '""' : 'something' }`
+
+      it(`when receiving ${type} (e.g. ${value}), it should ${expected}`, () => {
+        if (returns !== undefined) {
+          // @ts-ignore
+          expect(duration(value)).toBe(returns)
+        }
+      })
+    }
+  })
 })

--- a/src/duration.ts
+++ b/src/duration.ts
@@ -20,13 +20,23 @@ export const duration: DurationType = (
   }: DurationOptions = {},
 ) => {
   let count, result: [string, number][] = []
+  // console.log('calculating duration of', ms)
+
   for (let [unit, value] of Object.entries(units)) {
-    if (ms > value && parts-- > 0) {
+    // console.log('comparing ms', ms, 'to unit', unit, 'with value', value)
+    if ((ms >= value || unit == 'second') && parts-- > 0) {
+      // if (unit == 'second')
+        // console.log('calculating seconds of', ms)
       ms -= (count = ms / value | 0) * value
       if (!parts || unit == 'second') count += ms / value
-      if (count > 1) unit += 's'
+      if (count != 1) unit += 's'
+
+      // if (unit == 'second')
+        // console.log('calculated seconds', count)
+
       // @ts-ignore
       result.push(join ? count + ' ' + unit : [unit, count])
+      if (!ms) break
     }
   }
 

--- a/src/duration.ts
+++ b/src/duration.ts
@@ -20,20 +20,12 @@ export const duration: DurationType = (
   }: DurationOptions = {},
 ) => {
   let count, result: [string, number][] = []
-  // console.log('calculating duration of', ms)
 
   for (let [unit, value] of Object.entries(units)) {
-    // console.log('comparing ms', ms, 'to unit', unit, 'with value', value)
     if ((ms >= value || unit == 'second') && parts-- > 0) {
-      // if (unit == 'second')
-        // console.log('calculating seconds of', ms)
       ms -= (count = ms / value | 0) * value
       if (!parts || unit == 'second') count += ms / value
       if (count != 1) unit += 's'
-
-      // if (unit == 'second')
-        // console.log('calculated seconds', count)
-
       // @ts-ignore
       result.push(join ? count + ' ' + unit : [unit, count])
       if (!ms) break

--- a/src/ms.spec.ts
+++ b/src/ms.spec.ts
@@ -24,4 +24,36 @@ describe('ms(duration: string): number', () => {
       })
     }
   })
+
+  describe('INPUT HANDLING', () => {
+    const date = new Date
+
+    const inputTypes = [
+      { type: 'number', value: 1000, returns: 1000 },
+      { type: 'string duration', value: '1 hour', returns: 1000 * 60 * 60 },
+      { type: 'true', value: true, returns: 1 },
+      { type: 'date', value: date, returns: +date },
+      { type: 'false', value: false, throws: true },
+      { type: '0', value: 0, throws: true },
+      { type: 'unparsable string', value: '456apple', returns: NaN },
+      { type: 'object', value: {}, throws: true },
+      { type: 'function', value: () => {}, throws: true },
+    ]
+
+    for (const { type, value, throws, returns } of inputTypes) {
+      const expected = throws
+                        ? 'THROW AN ERROR'
+                        : `return ${returns}`
+
+      it(`when receiving ${type} (e.g. ${value}), it should ${expected}`, () => {
+        if (throws) {
+          // @ts-ignore
+          expect(() => ms(value)).toThrow()
+        } else {
+          // @ts-ignore
+          expect(ms(value)).toBe(returns)
+        }
+      })
+    }
+  })
 })


### PR DESCRIPTION
# Issue
`duration()` called with values under and including 1000 fail to return X.XX seconds.