### PR TITLE
Feature/string types

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   },
   "scripts": {
     "dev": "vitest --coverage --reporter verbose",
+    "check": "tsc --noEmit --watch",
+    "check:specs": "tsc --noEmit --watch --project tsconfig.specs.json",
     "lint": "yarn run eslint src",
     "test": "vitest run --coverage",
     "verify": "echo 'verifying module...' && yarn build && yarn test",

--- a/src/datePlus.spec.ts
+++ b/src/datePlus.spec.ts
@@ -1,9 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import { datePlus } from './datePlus'
 import { ms } from './ms'
+import type { DurationString } from './lib/units'
 
 describe('datePlus(duration: string, from?: Date): Date', () => {
-  type DatePlusTest = [duration: string]
+  type DatePlusTest = [duration: DurationString]
 
   const tests: DatePlusTest[] = [
     ['5 seconds'],

--- a/src/datePlus.ts
+++ b/src/datePlus.ts
@@ -1,5 +1,6 @@
+import type { DurationString } from 'lib/units'
 import { ms } from './ms'
 
 // FUNCTION: get future date from a duration string (e.g. datePlus('3 hours'))
-export const datePlus = (duration: string | number, from = new Date): Date =>
+export const datePlus = (duration: DurationString | number, from = new Date): Date =>
   new Date(from.getTime() + ms(duration))

--- a/src/duration.spec.ts
+++ b/src/duration.spec.ts
@@ -1,13 +1,14 @@
 import { describe, expect, it } from 'vitest'
 import { duration } from './duration'
 import { ms } from './ms'
+import type { TimeString } from './lib/units'
 
 const BASE = '1.1 weeks'
 const EXPECTED = '1 week, 16 hours, 48 minutes'
 
 describe('duration(ms: number, options?: durationOptions)', () => {
   describe('reverse-parses ms (number) into a readable string', () => {
-    const tests = [
+    const tests: Array<{ original: TimeString, parts?: number, expected: string }> = [
       { original: BASE, expected: '1 week, 16 hours, 48 minutes' },
       { original: BASE, parts: 2, expected: '1 week, 16.8 hours' },
       { original: BASE, parts: 1, expected: '1.1 weeks' },
@@ -17,7 +18,7 @@ describe('duration(ms: number, options?: durationOptions)', () => {
       { original: '2500', parts: 1, expected: '2.5 seconds' },
     ]
 
-    for (const { original, parts, expected = original } of tests) {
+    for (const { original, parts, expected } of tests) {
       it(original, () => {
         expect(duration(ms(original), { parts })).toBe(expected)
       })

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -12,6 +12,7 @@ describe('itty-time', () => {
   describe('exports', () => {
     for (const exportName of expected) {
       it(exportName, () => {
+        // @ts-ignore
         expect(typeof exports[exportName]).toBe('function')
       })
     }

--- a/src/lib/units.ts
+++ b/src/lib/units.ts
@@ -7,7 +7,7 @@ const
   month = day * 30,
   year = day * 365.25
 
-export const units: Record<string, number> = {
+export const units = {
   year,
   month,
   week,
@@ -16,4 +16,8 @@ export const units: Record<string, number> = {
   minute,
   second,
   m: 1,
-}
+} as const
+
+export type TimeUnit = keyof typeof units
+export type TimeUnitPlural = `${TimeUnit}s`
+export type TimeString = `${number} ${TimeUnit | TimeUnitPlural}`

--- a/src/lib/units.ts
+++ b/src/lib/units.ts
@@ -18,6 +18,8 @@ export const units = {
   m: 1,
 } as const
 
-export type TimeUnit = keyof typeof units
-export type TimeUnitPlural = `${TimeUnit}s`
-export type TimeString = `${number} ${TimeUnit | TimeUnitPlural}`
+export type DurationUnit = keyof typeof units
+export type DurationUnitPlural = `${DurationUnit}s`
+export type DurationString =
+  | `${number}`
+  | `${number} ${DurationUnit | DurationUnitPlural}`

--- a/src/ms.spec.ts
+++ b/src/ms.spec.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import { ms } from './ms'
+import type { DurationString } from './lib/units'
 
 describe('ms(duration: string): number', () => {
-  type MsTest = [duration: string | number, expected: number]
+  type MsTest = [duration: DurationString | number, expected: number]
 
   const tests: MsTest[] = [
     ['1 minutes', 60 * 1000],
@@ -14,6 +15,7 @@ describe('ms(duration: string): number', () => {
     [4001, 4001], // a number is assumed to be a number
     ['100', 100], // string of a number is assumed to be ms
     ['100 ms', 100], // can handle ms
+    // @ts-expect-error
     ['100apple', NaN], // can handle ms
   ]
 

--- a/src/ms.ts
+++ b/src/ms.ts
@@ -1,10 +1,11 @@
-import { units } from './lib/units'
+import { type DurationString, type DurationUnit, units } from './lib/units'
 
 // FUNCTION: get number of seconds from a duration string
-export const ms = (duration: string | number): number => {
+export const ms = (duration: DurationString | number): number => {
   if (+duration) return +duration
   // @ts-ignore
   const [, value, unit] = duration.match(/^([^ ]+) +(\w\w*?)s?$/) || []
 
-  return +value * (units[unit] || 1)
+  // Note: This `as` is safe because the `|| 1` handles missing units
+  return +value * (units[unit as DurationUnit] || 1)
 }

--- a/src/seconds.spec.ts
+++ b/src/seconds.spec.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'vitest'
 import { seconds } from './seconds'
+import type { DurationString } from './lib/units'
 
 describe('seconds(duration: string): number', () => {
-  type SecondsTest = [duration: string | number, expected: number]
+  type SecondsTest = [duration: DurationString | number, expected: number]
 
   const tests: SecondsTest[] = [
     ['5 seconds', 5],
@@ -13,6 +14,8 @@ describe('seconds(duration: string): number', () => {
     ['1.5 seconds', 1.5],
     ['-30 seconds', -30],
     [10000, 10],
+    // @ts-expect-error
+    ['not-a-timestring', NaN],
   ]
 
   describe('returns number of seconds', () => {

--- a/src/seconds.ts
+++ b/src/seconds.ts
@@ -1,4 +1,5 @@
+import type { DurationString } from 'lib/units'
 import { ms } from './ms'
 
-export const seconds = (duration: string | number): number =>
+export const seconds = (duration: DurationString | number): number =>
   ms(duration) / 1000

--- a/tsconfig.specs.json
+++ b/tsconfig.specs.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "exclude": ["node_modules", "dist", "examples"],
+  "compilerOptions": {
+    "moduleResolution": "NodeNext",
+    "module": "NodeNext",
+    "types": ["@types/node", "vitest/globals"]
+  }
+}


### PR DESCRIPTION
@kwhitley This adds typing to the top level functions. There is a notable downside for folks using this to parse arbitrary strings:

```svelte
<script lang='ts'>
  import { seconds } from "itty-time";

  let duration: string = '12 ms';

  // @ts-ignore
  let asSeconds = derived(seconds(duration));
</script>

<label>Input your duration: <input type='text' bind:value={duration} /></label>
<hr />
<p>
  {duration} = {asSeconds} seconds.
</p>
```

The `@ts-ignore` is needed to inform typescript that the code actually _does_ handle arbitrary strings gracefully. Unfortunately if you just add `string` to the `ms`/`second`/`datePlus` types you lose all the TS help when you use the function, so:

```ts
// Below where the `*` is typescript does not give suggestions if we add `string`
dateAdd('-4 w*')
```

This is actually OK, because it forces folks to think about it, but it *may* be better to return a `null` so the function types all start to look something like this (this is encodable in an interface type so we still get the itty byte shaving for using a const):

```ts
function fnName(duration: DurationString, date: Date): number;
function fnName(duration: number, date: Date): number;
function fnName(duration: string, date: Date): null;
```

`NaN` is not currently a legal Typescript literal type, so we can't encode it that way.

The obvious downside here is that we have to add `?? null` in 4ish places, resulting in 20-25 added bytes to the final library. The obvious solution seems to be letting the type error be the warning and adding tsdocs to explain how to handle type errors correctly.