### PR TITLE
Fix: `ms` breaking when called with 0

### DIFF
--- a/src/ms.ts
+++ b/src/ms.ts
@@ -2,7 +2,7 @@ import { units } from './lib/units'
 
 // FUNCTION: get number of seconds from a duration string
 export const ms = (duration: string | number): number => {
-  if (+duration) return +duration
+  if (+duration === duration) return +duration
   // @ts-ignore
   const [, value, unit] = duration.match(/^([^ ]+) +(\w\w*?)s?$/) || []
 


### PR DESCRIPTION
`ms` was throwing an error when called with 0. The fix for this was changing the number validation.