### PR TITLE
adds TimeString type checking for duration strings (v2)

### DIFF
--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,6 +17,5 @@ jobs:
         run: bun install
       - name: Build
         run: bun run build
-
       - name: Test types
         run: bun run test:types

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -17,3 +17,6 @@ jobs:
         run: bun install
       - name: Build
         run: bun run build
+
+      - name: Test types
+        run: bun run test:types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## Changelog
 
+#### v2.1.0
+- added: TimeString/TimeUnit types - duration strings passed to ms/seconds/datePlus are now type-checked
 #### v2.0.0
 - BREAKING: to allow 0, false, and '0' as valid arguments for ms, tests had to be changed.
 - removed: sourcemaps in dist version (additional size savings)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### v2.1.0
 - added: TimeString/TimeUnit types - duration strings passed to ms/seconds/datePlus are now type-checked
+- BREAKING (types only): TS code passing plain strings (e.g. user input) must cast via `as TimeString` - runtime behavior is unchanged
 #### v2.0.0
 - BREAKING: to allow 0, false, and '0' as valid arguments for ms, tests had to be changed.
 - removed: sourcemaps in dist version (additional size savings)

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ Use Luke's if you want the absolute fastest parsing, or itty if you want some of
 
 ## seconds/ms
 <h4>
-  <code>seconds(duration: string) => number</code><br />
-  <code>ms(duration: string) => number</code><br />
+  <code>seconds(duration: TimeString | number) => number</code><br />
+  <code>ms(duration: TimeString | number) => number</code><br />
 </h4>
 
 TTL math is a maintenance nightmare. It's a pain to write, a pain to read, and when you update the math later, you'll probably forget to update the comment, causing all sorts of mayhem.
@@ -74,6 +74,14 @@ seconds('2 weeks') // 1209600
 
 // to milliseconds
 ms('2 weeks') // 1209600000
+```
+
+Duration strings are typed as `TimeString`, so typos like `ms('2 weekz')` fail at compile time rather than silently misbehaving.  If you're parsing arbitrary user input (that you've validated yourself), cast it:
+
+```ts
+import { ms, type TimeString } from 'itty-time'
+
+ms(userInput as TimeString)
 ```
 
 ## duration
@@ -114,7 +122,7 @@ duration(3750000, { join: false })
 
 ## datePlus
 <h4>
-  <code>datePlus(duration: string, from = new Date) => Date</code>
+  <code>datePlus(duration: TimeString | number, from = new Date) => Date</code>
 </h4>
 
 Sometimes you need a TTL for some point in the future, but sometimes you need the actual date.  You could convert it all yourself... or use this.

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "scripts": {
     "dev": "bun test --watch --coverage",
     "test": "bun test --coverage",
+    "test:types": "tsc -p tsconfig.spec.json",
     "lint": "itty lint",
     "build": "itty lint && itty build --hybrid",
     "release": "itty release --prepare --tag --push",

--- a/src/datePlus.spec.ts
+++ b/src/datePlus.spec.ts
@@ -1,9 +1,9 @@
 import { describe, expect, it } from 'bun:test'
 import { datePlus } from './datePlus'
-import { ms } from './ms'
+import { ms, type TimeString } from './ms'
 
 describe('datePlus(duration: string, from?: Date): Date', () => {
-  type DatePlusTest = [duration: string]
+  type DatePlusTest = [duration: TimeString]
 
   const tests: DatePlusTest[] = [
     ['5 seconds'],

--- a/src/datePlus.ts
+++ b/src/datePlus.ts
@@ -1,5 +1,6 @@
 import { ms } from './ms'
+import { type TimeString } from './lib/units'
 
 // FUNCTION: get future date from a duration string (e.g. datePlus('3 hours'))
-export const datePlus = (duration: string | number, from = new Date): Date =>
+export const datePlus = (duration: TimeString | number, from = new Date): Date =>
   new Date(from.getTime() + ms(duration))

--- a/src/duration.spec.ts
+++ b/src/duration.spec.ts
@@ -1,13 +1,13 @@
 import { describe, expect, it } from 'bun:test'
 import { duration } from './duration'
-import { ms } from './ms'
+import { ms, type TimeString } from './ms'
 
 const BASE = '1.1 weeks'
 const EXPECTED = '1 week, 16 hours, 48 minutes'
 
 describe('duration(ms: number, options?: durationOptions)', () => {
   describe('reverse-parses ms (number) into a readable string', () => {
-    const tests = [
+    const tests: { original: TimeString, parts?: number, expected?: string }[] = [
       { original: BASE, expected: '1 week, 16 hours, 48 minutes' },
       { original: BASE, parts: 2, expected: '1 week, 16.8 hours' },
       { original: BASE, parts: 1, expected: '1.1 weeks' },

--- a/src/index.spec.ts
+++ b/src/index.spec.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'bun:test'
 import * as exports from './index'
 
-const expected = [
+const expected: (keyof typeof exports)[] = [
   'seconds',
   'ms',
   'duration',

--- a/src/lib/units.ts
+++ b/src/lib/units.ts
@@ -7,6 +7,19 @@ const
   month = day * 30,
   year = day * 365.25
 
+export type TimeUnit =
+  | 'ms'
+  | 'millisecond' | 'milliseconds'
+  | 'second' | 'seconds'
+  | 'minute' | 'minutes'
+  | 'hour' | 'hours'
+  | 'day' | 'days'
+  | 'week' | 'weeks'
+  | 'month' | 'months'
+  | 'year' | 'years'
+
+export type TimeString = `${number}` | `${number} ${TimeUnit}`
+
 export const units: Record<string, number> = {
   year,
   month,

--- a/src/ms.spec.ts
+++ b/src/ms.spec.ts
@@ -36,7 +36,7 @@ describe('ms(duration: string): number', () => {
       { type: 'date', value: date, returns: +date },
       { type: 'false', value: false, returns: 0 },
       { type: '0 (string)', value: '0', returns: 0 },
-      { type: '0', value: '0', returns: 0 },
+      { type: '0', value: 0, returns: 0 },
       { type: 'unparsable string', value: '456apple', returns: NaN },
       { type: 'object', value: {}, throws: true },
       { type: 'function', value: () => {}, throws: true },

--- a/src/ms.spec.ts
+++ b/src/ms.spec.ts
@@ -1,8 +1,8 @@
 import { describe, expect, it } from 'bun:test'
-import { ms } from './ms'
+import { ms, type TimeString } from './ms'
 
 describe('ms(duration: string): number', () => {
-  type MsTest = [duration: string | number, expected: number]
+  type MsTest = [duration: TimeString | number, expected: number]
 
   const tests: MsTest[] = [
     ['1 minutes', 60 * 1000],
@@ -10,11 +10,12 @@ describe('ms(duration: string): number', () => {
     ['2 years', 2 * 365.25 * 24 * 60 * 60 * 1000],
     ['321 day', 60 * 60 * 24 * 321 * 1000],
     ['30.5 seconds', 30.5 * 1000],
-    ['30.5   seconds', 30.5 * 1000],
+    ['30.5   seconds' as TimeString, 30.5 * 1000], // extra whitespace still parses at runtime
     [4001, 4001], // a number is assumed to be a number
     ['100', 100], // string of a number is assumed to be ms
     ['100 ms', 100], // can handle ms
-    ['100apple', NaN], // can handle ms
+    ['100 milliseconds', 100], // can handle milliseconds
+    ['100apple' as TimeString, NaN], // unparsable strings return NaN at runtime
   ]
 
   describe('returns number of Ms', () => {

--- a/src/ms.ts
+++ b/src/ms.ts
@@ -1,7 +1,9 @@
-import { units } from './lib/units'
+import { units, type TimeString } from './lib/units'
+
+export type { TimeString, TimeUnit } from './lib/units'
 
 // FUNCTION: get number of seconds from a duration string
-export const ms = (duration: string | number): number => {
+export const ms = (duration: TimeString | number): number => {
   if (!isNaN(+duration)) return +duration
 
   // @ts-ignore

--- a/src/seconds.spec.ts
+++ b/src/seconds.spec.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from 'bun:test'
 import { seconds } from './seconds'
+import { type TimeString } from './lib/units'
 
 describe('seconds(duration: string): number', () => {
-  type SecondsTest = [duration: string | number, expected: number]
+  type SecondsTest = [duration: TimeString | number, expected: number]
 
   const tests: SecondsTest[] = [
     ['5 seconds', 5],

--- a/src/seconds.ts
+++ b/src/seconds.ts
@@ -1,4 +1,5 @@
 import { ms } from './ms'
+import { type TimeString } from './lib/units'
 
-export const seconds = (duration: string | number): number =>
+export const seconds = (duration: TimeString | number): number =>
   ms(duration) / 1000

--- a/src/types.spec.ts
+++ b/src/types.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'bun:test'
+import { datePlus } from './datePlus'
+import { ms } from './ms'
+import { seconds } from './seconds'
+import { type TimeString } from './lib/units'
+
+// The @ts-expect-error assertions below are verified by `bun run test:types`,
+// since bun test does not type-check.
+describe('TimeString type checking', () => {
+  it('accepts every format the type allows', () => {
+    const durations: TimeString[] = [
+      '100',
+      '100 ms',
+      '100 millisecond',
+      '100 milliseconds',
+      '30.5 seconds',
+      '-30 minutes',
+      '1.5 hours',
+      '1 day',
+      '2 weeks',
+      '3 months',
+      '4 years',
+    ]
+
+    for (const duration of durations) {
+      expect(ms(duration)).not.toBeNaN()
+      expect(seconds(duration)).not.toBeNaN()
+      expect(+datePlus(duration)).not.toBeNaN()
+    }
+  })
+
+  it('rejects invalid durations at compile time', () => {
+    // @ts-expect-error - arbitrary strings are not valid durations
+    expect(ms('lskdjfsdlkfjsdlfkjsd')).toBeNaN()
+
+    // @ts-expect-error - duration values must be numeric
+    expect(seconds('one hour')).toBeNaN()
+
+    // unit typos silently fall back to ms at runtime - the type catches them
+    // @ts-expect-error - unsupported units are rejected
+    expect(ms('2 weekz')).toBe(2)
+
+    // @ts-expect-error - unsupported units are rejected
+    expect(+datePlus('2 apples', new Date(1000))).toBe(1002)
+  })
+})

--- a/src/types.spec.ts
+++ b/src/types.spec.ts
@@ -8,24 +8,24 @@ import { type TimeString } from './lib/units'
 // since bun test does not type-check.
 describe('TimeString type checking', () => {
   it('accepts every format the type allows', () => {
-    const durations: TimeString[] = [
-      '100',
-      '100 ms',
-      '100 millisecond',
-      '100 milliseconds',
-      '30.5 seconds',
-      '-30 minutes',
-      '1.5 hours',
-      '1 day',
-      '2 weeks',
-      '3 months',
-      '4 years',
+    const durations: [duration: TimeString, expected: number][] = [
+      ['100', 100],
+      ['100 ms', 100],
+      ['100 millisecond', 100],
+      ['100 milliseconds', 100],
+      ['30.5 seconds', 30.5 * 1000],
+      ['-30 minutes', -30 * 60 * 1000],
+      ['1.5 hours', 1.5 * 60 * 60 * 1000],
+      ['1 day', 24 * 60 * 60 * 1000],
+      ['2 weeks', 2 * 7 * 24 * 60 * 60 * 1000],
+      ['3 months', 3 * 30 * 24 * 60 * 60 * 1000],
+      ['4 years', 4 * 365.25 * 24 * 60 * 60 * 1000],
     ]
 
-    for (const duration of durations) {
-      expect(ms(duration)).not.toBeNaN()
-      expect(seconds(duration)).not.toBeNaN()
-      expect(+datePlus(duration)).not.toBeNaN()
+    for (const [duration, expected] of durations) {
+      expect(ms(duration)).toBe(expected)
+      expect(seconds(duration)).toBe(expected / 1000)
+      expect(+datePlus(duration, new Date(0))).toBe(expected)
     }
   })
 

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true,
+    "types": ["bun"]
+  },
+  "exclude": ["node_modules", "dist", "examples"],
+  "include": ["src"]
+}


### PR DESCRIPTION
## Changelog
- adds: `TimeUnit` + `TimeString` types in `lib/units` — duration strings passed to `ms`/`seconds`/`datePlus` are now type-checked, so typos like `ms('2 weekz')` or `ms('one hour')` fail at compile time
- both types are re-exported from `ms` (and therefore the root index), so users can type their own APIs with them
- `TimeString` also accepts bare numeric strings (`'100'`) and negative/decimal values (`'-30 minutes'`, `'1.5 hours'`), matching existing runtime behavior
- adds: `types.spec.ts` — asserts the exact runtime value for every format the type accepts, plus `@ts-expect-error` cases for invalid durations (including `ms('2 weekz')` silently returning `2` at runtime, which the type now catches)
- adds: `test:types` script (`tsc -p tsconfig.spec.json`) so the `@ts-expect-error` assertions are actually enforced — `bun test` doesn't type-check — wired into the verify workflow; no new devDeps, `tsc` already comes in via itty-packager

> **Why a separate `tsconfig.spec.json`?** The base tsconfig is the build config: it excludes specs so declaration emit doesn't ship `*.spec.d.ts` into dist, and compiles against node types. The spec config just extends it with specs included, `types: ["bun"]` (for `bun:test`), and `noEmit` — same strict rules, no build changes.

This brings the type checking from #11 (currently open against v1.x) to v2.x, in the same shape you wrote there. Compared to #11 it additionally covers `millisecond(s)` units and bare numeric strings, and exposes the types publicly.

**Zero runtime changes** — types are fully erased, bundle sizes are byte-for-byte identical (`ms` still 202 B gzipped). No `?? null` tax from the #12 discussion; for arbitrary user input the README now documents the escape hatch:

```ts
ms(userInput as TimeString)
```

**Heads up on versioning:** this is a types-only break — TS callers currently passing a plain `string` variable will need the cast above (runtime is untouched). Flagged as `BREAKING (types only)` in the CHANGELOG so you can decide how to version it.

All 70 tests pass, `test:types`, lint, and build are clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)